### PR TITLE
Metrikker volum 2

### DIFF
--- a/src/main/java/no/nav/kontantstotte/proxy/innsending/dokument/dokmot/DokmotJMSSender.java
+++ b/src/main/java/no/nav/kontantstotte/proxy/innsending/dokument/dokmot/DokmotJMSSender.java
@@ -13,6 +13,7 @@ import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsTemplate;
 
 import javax.jms.TextMessage;
+import java.util.Base64;
 
 public class DokmotJMSSender implements SoknadSender {
 
@@ -42,7 +43,7 @@ public class DokmotJMSSender implements SoknadSender {
 
         try {
             String soknadXML = generator.toXML(soknad);
-            dokmotMeldingStorrelse.record(soknadXML.length());
+            dokmotMeldingStorrelse.record(Base64.getEncoder().encode(soknadXML.getBytes()).length);
             template.send(session -> {
                 LOG.info("Sender SoknadsXML til DOKMOT");
                 TextMessage msg = session.createTextMessage(soknadXML);

--- a/src/main/java/no/nav/kontantstotte/proxy/innsending/dokument/dokmot/DokmotJMSSender.java
+++ b/src/main/java/no/nav/kontantstotte/proxy/innsending/dokument/dokmot/DokmotJMSSender.java
@@ -41,12 +41,12 @@ public class DokmotJMSSender implements SoknadSender {
         }
 
         try {
+            String soknadXML = generator.toXML(soknad);
+            dokmotMeldingStorrelse.record(soknadXML.length());
             template.send(session -> {
                 LOG.info("Sender SoknadsXML til DOKMOT");
-                String soknadXML = generator.toXML(soknad);
                 TextMessage msg = session.createTextMessage(soknadXML);
                 msg.setStringProperty("callId", MDC.get(MDCConstants.MDC_CORRELATION_ID));
-                dokmotMeldingStorrelse.record(soknadXML.length());
                 return msg;
             });
             dokmotSuccess.increment();


### PR DESCRIPTION
* Rapporter meldingsstørrelse til DOKMOT selv om kø feiler
* Litt smartere måte å kalkulere antall bytes på, tar hensyn til base64-enkodingen på køen. Hvis noen vet hva slags charset som faktisk brukes, skrik ut 🙋Nå bruker den bare default for systemet, men hadde vært bedre å sette noe spesifikt (stor forskjell på UTF-8 og -16 feks). 
